### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Une fois lancée, cette API met plusieurs routes à votre disposition :
   `GET /freelances`
 
 - La route pour avoir le détail d'un profil de freelance :
-  `GET /profile/?id={id}`
+  `GET /freelance/?id={id}`
 
 - La route pour avoir le questionnaire :
   `GET /survey/`


### PR DESCRIPTION
La route pour avoir le détail d'un profil de freelance est erronée. L'endpoint est en effet `/freelance/?id={id}` et non `/profile/?id={id}`.